### PR TITLE
Fix images with `img` tags not displaying

### DIFF
--- a/docs/guides/platform/Forgot_Password.md
+++ b/docs/guides/platform/Forgot_Password.md
@@ -7,56 +7,56 @@ This document simply describes how to set up the Email configurations and enable
 Step 1, Go to the project which installed Merlin  
 Go to the Openshift GUI, **Home** -> **Projects** -> click specific project  
 
-<img src="../../images/guides/forgotp1.png" width = "800" height = "600" alt="Projects" align=center />  
+![Projects](../../images/guides/forgotp1.png ':size=800')
 
 Step 2, Get the credential of keycloak  
 **Workloads** -> **Secrets** -> click **merlin-credential-secret** in the table  
 
-<img src="../../images/guides/forgotp2.png" width = "800" height = "600" alt="Secrets" align=center />  
+![Secrets](../../images/guides/forgotp2.png ':size=800')
 
 Get **ADMIN_USERNAME** and **ADMIN_PASSWORD**  
 
-<img src="../../images/guides/forgotp3.png" width = "800" height = "600" alt="admin_password" align=center />    
+![Admin Password](../../images/guides/forgotp3.png ':size=800')
 
 Step 3, Find the route of keycloak  
 **Networking** -> **Routes** -> Click the Location link in the keykloak item. It will open the Keycloak GUI.  
 
-<img src="../../images/guides/forgotp4.png" width = "800" height = "600" alt="Route" align=center />  
+![Route](../../images/guides/forgotp4.png ':size=800')
 
 Step 4, Login  
 Click the **Administration Console**.  
 
-<img src="../../images/guides/forgotp5.png" width = "800" height = "600" alt="Console" align=center />  
+![Console](../../images/guides/forgotp5.png ':size=800')
 
 Login with **ADMIN_USERNAME** and **ADMIN_PASSWORD**  
 
-<img src="../../images/guides/forgotp6.png" width = "800" height = "600" alt="login_1" align=center />  
+![Login](../../images/guides/forgotp6.png ':size=800')
 
 Step 5, Set up Email  
 **Realm Settings** -> Click **Email** tab -> enter the necessary info -> Click Save button.  
 
-<img src="../../images/guides/forgotp7.png" width = "800" height = "600" alt="login_2" align=center />  
+![Keycloak Config](../../images/guides/forgotp7.png ':size=800')
 
 Step 6, Enable Forgot Password   
 **Realm Settings** -> Click **Login** tab -> enable the Forgot Password -> click Save button.  
 
-<img src="../../images/guides/forgotp8.png" width = "800" height = "600" alt="login_3" align=center />  
+![Forgot Password](../../images/guides/forgotp8.png ':size=800') 
 
 Step 7, Verify the Forgot Password was enabled  
 Go to the Merlin login page -> click **Forgot Password**  
 
-<img src="../../images/guides/forgotp9.png" width = "800" height = "600" alt="login_4" align=center />  
+![Forgot Password](../../images/guides/forgotp9.png ':size=800')
 
 Enter the username or email address -> click Submit.  
 
-<img src="../../images/guides/forgotp10.png" width = "800" height = "600" alt="username" align=center />
+![Username or Email](../../images/guides/forgotp10.png ':size=800')
 
 Note: please make sure this account has set up a valid email address in profile, or this account could not receive emails.  
 Received a Reset Password Email. 
 
-<img src="../../images/guides/forgotp11.png" width = "800" height = "600" alt="reset" align=center /> 
+![Reset Password Email](../../images/guides/forgotp11.png ':size=800')
 
 Step 8, Reset password  
 Click the link to reset credentials in the Email -> enter the new password -> click submit, then the password will be reset.
 
-<img src="../../images/guides/forgotp12.png" width = "800" height = "600" alt="submit" align=center />  
+![Submit](../../images/guides/forgotp12.png ':size=800')

--- a/docs/guides/platform/ManageCredential.md
+++ b/docs/guides/platform/ManageCredential.md
@@ -3,7 +3,7 @@ The Credentials manage the credential info used for Merlin. It will save the cre
 
 Go to Merlin GUI and select **Connections -> Credentials** to go to the Credentials page.  
 
-<img src="../../images/guides/Credentials.png" width = "800" height = "500" alt="Credential" align=center />
+![Credentials Page](../../images/guides/Credentials.png ':size=800')
 
 An admin will see all credentials, but a user will only see credentials which they own. It will display the `Name`, `Type`, `Description`, `Owner`, `Created Time`, and `Updated Time`. 
 
@@ -11,7 +11,7 @@ An admin will see all credentials, but a user will only see credentials which th
 
   **Note**: If using ssh key, additional configuration is performed during connection to the IBM i before the build starts.  
 
-  <img src="../../images/guides/AddCredentials.png" width = "600" height = "300" alt="Add Credential" align=center />
+  ![Add Credential](../../images/guides/AddCredentials.png ':size=600')
 
 - **Delete Credentials** - The `Delete` button is disabled by default. Selecting items in the credential table will highlight them and also enable the `Delete` button. Click the `Delete` button and click `Yes` to the confirmation to delete all selected items.
 

--- a/docs/guides/platform/ManageInventory.md
+++ b/docs/guides/platform/ManageInventory.md
@@ -2,20 +2,20 @@
 The Inventory manages the systems information used for Merlin. It will save the general system information including hostname, type, description and some other information. The detailed inventory info will be changed according to the inventory type. Merlin supports four types of hosts: `IBM i`, `IBM PowerVC`, `IBM Cloud`, and `Jenkins`.  
 
 Go to Merlin GUI and select **Connections -> Inventory** to go to the Inventory page.    
-    
-<img src="../../images/guides/Addinventory0.png" width = "800" height = "500" alt="Inventory" align=center />  
+
+![Inventory Page](../../images/guides/Addinventory0.png ':size=800')
 
 All the inventories which the user created or has permission to will be shown. It will display the `Name`, `Hostname`, `Type`, `Description`, `Owner`, `Provision`, `Created Time`, and `Updated Time`. The `Provision` item is a tag that specifies the IBM i server deployed by the Power VC template.  
 
 - **Add Inventory** - Click the `+ Add` button and enter the `Name`, `Type` and `Hostname`.  After the type is selected, the required fields will updated. If one of requirements are not meet,  the `+ Add` button will stay disabled. Specify all the necessary fields and click the `+ Add` button so then the new inventory record will be imported to the Inventory table.
 
-  <img src="../../images/guides/Addinventory.png" width = "400" height = "250" alt="Add Inventory" align=center />    
+  ![Add Inventory](../../images/guides/Addinventory.png ':size=600')
 
   For secure connections, Merlin supports the `Test TLS` function which allows customers to accept the remote CA such as for a Power VC Inventory. After specifying the `Hostname` and `Port`, the `Test TLS` button will be enabled and it will catch the Power VC CA. In the detailed certificate windows, click the `Accept` button. Then this CA be added to the Merlin trust store.
 
-  <img src="../../images/guides/Pvcinventory.png" width = "400" height = "300" alt="Add power vc inventory" align=center />  
+  ![Add Power VC Inventory](../../images/guides/Pvcinventory.png ':size=600')
 
-**Note:** For the `Name` field, please avoid the use of the special characters .,:;/\"*?<>|=+&%'\`@". The `Hostname` field supports `IP`, `Hostname`, and `URL`.  
+  **Note:** For the `Name` field, please avoid the use of the special characters .,:;/\"*?<>|=+&%'\`@". The `Hostname` field supports `IP`, `Hostname`, and `URL`.  
 
 - **Delete Inventory** - The `Delete` button is disabled by default. Selecting items in the inventory table will highlight them and also enable the `Delete` button. Click the `Delete` button and click `Yes` to the confirmation to delete all selected items.
 

--- a/docs/guides/platform/ManageTemplates.md
+++ b/docs/guides/platform/ManageTemplates.md
@@ -3,13 +3,13 @@ The Templates manage the template info used for Merlin. It will save the templat
 
 Go to Merlin GUI and select **Connections -> Templates** to go to the Templates page.  
 
-<img src="../../images/guides/Templates.png" width = "800" height = "500" alt="Templates" align=center />  
+![Templates Page](../../images/guides/Templates.png ':size=800') 
 
 An admin will see all templates, but the `Run` button will only work on templates which they own. A user will only see templates which they own. It will display the `Name`, `Inventory`, `Credential`, `Type`, `Owner`, `Created Time`, and `Updated Time` by default. Users can also customize the columns by clicking the icon at the top right of the table.
 
 - **Add Template** - Click the `+ Add` button and enter the `Name` and select an inventory. The `type` will be automatically populated to be the same as the inventory type. The listed credentials to select from will also be filtered to match the same type. After the type is set, the required fields will updated. For example, if `IBM PowerVC` is the set type, users must enter the vm info which is used in this template or the `+ Add` button will be disabled. Specify all the necessary fields and click the `+ Add` button so then the new template record will be imported to the Templates table.
 
-  <img src="../../images/guides/PvcTemplate.png" width = "600" height = "400" alt="Add Templates" align=center />
+  ![Add Template](../../images/guides/PvcTemplate.png ':size=600') 
 
 - **Delete Templates** - The `Delete` button is disabled by default. Selecting items in the credential table will highlight them and also enable the `Delete` button. Click the `Delete` button and click `Yes` to the confirmation to delete all selected items.
 
@@ -17,10 +17,10 @@ An admin will see all templates, but the `Run` button will only work on template
 
 - **Run Template** - The `Run` button is disabled by default. Selecting one item in the template table will highlight it and also enable the `Run` button. According to the different templates type, the available actions will be different. For a Power VC template, Merlin supports the Provision actions which will help the user to deploy a new IBM VM. The user should make sure all the hardware configurations have been set up on the Power VC side.    
 
-  <img src="../../images/guides/PvcAction.png" width = "600" height = "200" alt="Power VC Templates Action" align=center />  
+  ![Power VC Template Actions](../../images/guides/PvcAction.png ':size=800') 
 
   For the IBM i server template, Merlin supports `Enable Ansible environment`, `Validate the dependent PTFs`, `Install Certificate`, `Enable IBM i developer environment`, `Enable IBM i Debug Service`, and `Enable ARCAD environment`.   
 
-  <img src="../../images/guides/IAction.png" width = "600" height = "200" alt="IBM i Templates Action" align=center />  
+  ![IBM i Template Actions](../../images/guides/IAction.png ':size=800') 
 
 - **Refresh Templates** - Click the `Refresh` button for the Merlin GUI to retrieve the latest template info.


### PR DESCRIPTION
Old images with `img` tags work when running the docs site locally, but don't display on the published docs site.